### PR TITLE
fix: fix di for discussion fragments

### DIFF
--- a/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/di/module/ArticleCommentsModule.kt
+++ b/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/di/module/ArticleCommentsModule.kt
@@ -1,7 +1,6 @@
 package com.makentoshe.habrachan.application.android.screen.comments.di.module
 
 import com.makentoshe.habrachan.application.android.common.comment.viewmodel.GetArticleCommentsViewModel
-import com.makentoshe.habrachan.application.android.common.comment.viewmodel.GetArticleCommentsViewModelProvider
 import com.makentoshe.habrachan.application.android.di.ApplicationScope
 import com.makentoshe.habrachan.application.android.screen.comments.ArticleCommentsFragment
 import com.makentoshe.habrachan.application.android.screen.comments.di.CommentsScope
@@ -26,7 +25,6 @@ class ArticleCommentsModule(private val fragment: ArticleCommentsFragment) : Mod
         bind<ArticleCommentsArena>().toInstance(articleCommentsArena)
 
         val factory = GetArticleCommentsViewModel.Factory(userSession, articleCommentsArena)
-        val provider = GetArticleCommentsViewModelProvider(factory)
-        bind<GetArticleCommentsViewModelProvider>().toInstance(provider)
+        bind<GetArticleCommentsViewModel.Factory>().toInstance(factory)
     }
 }

--- a/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/di/module/CommentsModule.kt
+++ b/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/di/module/CommentsModule.kt
@@ -7,13 +7,11 @@ import com.makentoshe.habrachan.application.android.common.comment.controller.bl
 import com.makentoshe.habrachan.application.android.common.comment.controller.comment.body.content.ContentBodyComment
 import com.makentoshe.habrachan.application.android.common.comment.viewmodel.VoteCommentViewModel
 import com.makentoshe.habrachan.application.android.di.ApplicationScope
-import com.makentoshe.habrachan.application.android.navigation.StackRouter
 import com.makentoshe.habrachan.application.android.screen.comments.ArticleCommentsFragment
 import com.makentoshe.habrachan.application.android.screen.comments.DiscussionCommentsFragment
 import com.makentoshe.habrachan.application.android.screen.comments.di.provider.ContentBodyBlockFactoryProvider
 import com.makentoshe.habrachan.application.android.screen.comments.di.provider.ContentBodyCommentFactoryProvider
 import com.makentoshe.habrachan.application.android.screen.comments.di.provider.VoteCommentViewModelFactoryProvider
-import com.makentoshe.habrachan.application.android.screen.comments.navigation.CommentsNavigation
 import com.makentoshe.habrachan.application.common.arena.comments.ArticleCommentsArena
 import com.makentoshe.habrachan.network.manager.GetArticleCommentsManager
 import com.makentoshe.habrachan.network.request.GetArticleCommentsRequest
@@ -32,9 +30,6 @@ class CommentsModule(articleId: Int, articleTitle: String, fragment: Fragment) :
         fragment.arguments.articleId, fragment.arguments.articleTitle, fragment
     )
 
-    // From ApplicationScope
-    private val router by inject<StackRouter>()
-
     private val getArticleCommentsManager by inject<GetArticleCommentsManager<GetArticleCommentsRequest>>()
     private val arenaCache by inject<ArticleCommentsArenaCache>()
 
@@ -42,13 +37,9 @@ class CommentsModule(articleId: Int, articleTitle: String, fragment: Fragment) :
         Toothpick.openScopes(ApplicationScope::class).inject(this)
         bind<Context>().toInstance(fragment.requireActivity())
 
-        val navigation = CommentsNavigation(router, articleId, articleTitle, fragment.childFragmentManager)
-        bind<CommentsNavigation>().toInstance(navigation)
-
         bind<ContentBodyBlock.Factory>().toProvider(ContentBodyBlockFactoryProvider::class)
         bind<ContentBodyComment.Factory>().toProvider(ContentBodyCommentFactoryProvider::class)
         bind<VoteCommentViewModel.Factory>().toProvider(VoteCommentViewModelFactoryProvider::class)
-//        bind<ArticleCommentsViewModelProvider>().toClass(ArticleCommentsViewModelProvider::class)
 
         bind<ArticleCommentsArena.Factory>().toInstance(ArticleCommentsArena.Factory(getArticleCommentsManager, arenaCache))
     }

--- a/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/di/module/DiscussionCommentsModule.kt
+++ b/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/di/module/DiscussionCommentsModule.kt
@@ -6,7 +6,6 @@ import com.makentoshe.habrachan.application.android.screen.comments.DiscussionCo
 import com.makentoshe.habrachan.application.android.screen.comments.di.CommentsScope
 import com.makentoshe.habrachan.application.android.screen.comments.di.provider.DiscussionCommentsViewModelFactoryProvider
 import com.makentoshe.habrachan.application.android.screen.comments.viewmodel.DiscussionCommentsViewModel
-import com.makentoshe.habrachan.application.android.screen.comments.viewmodel.DiscussionCommentsViewModelProvider
 import toothpick.Toothpick
 import toothpick.config.Module
 import toothpick.ktp.binding.bind
@@ -18,6 +17,5 @@ class DiscussionCommentsModule(private val fragment: DiscussionCommentsFragment)
         bind<Context>().toInstance(fragment.requireActivity())
 
         bind<DiscussionCommentsViewModel.Factory>().toProvider(DiscussionCommentsViewModelFactoryProvider::class)
-        bind<DiscussionCommentsViewModelProvider>().toClass<DiscussionCommentsViewModelProvider>()
     }
 }

--- a/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/di/module/SpecifiedArticleCommentsModule.kt
+++ b/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/di/module/SpecifiedArticleCommentsModule.kt
@@ -6,12 +6,13 @@ import com.makentoshe.habrachan.application.android.common.comment.viewmodel.Get
 import com.makentoshe.habrachan.application.android.common.comment.viewmodel.VoteCommentViewModel
 import com.makentoshe.habrachan.application.android.common.comment.viewmodel.VoteCommentViewModelProvider
 import com.makentoshe.habrachan.application.android.di.ApplicationScope
+import com.makentoshe.habrachan.application.android.navigation.StackRouter
 import com.makentoshe.habrachan.application.android.screen.comments.ArticleCommentsFragment
 import com.makentoshe.habrachan.application.android.screen.comments.di.ArticleCommentsScope2
 import com.makentoshe.habrachan.application.android.screen.comments.di.CommentsScope
 import com.makentoshe.habrachan.application.android.screen.comments.di.provider.ContentCommentAdapterProvider
 import com.makentoshe.habrachan.application.android.screen.comments.model.adapter.ContentCommentAdapter
-import com.makentoshe.habrachan.network.UserSession
+import com.makentoshe.habrachan.application.android.screen.comments.navigation.CommentsNavigation
 import toothpick.Toothpick
 import toothpick.config.Module
 import toothpick.ktp.binding.bind
@@ -19,24 +20,34 @@ import toothpick.ktp.delegate.inject
 
 class SpecifiedArticleCommentsModule(fragment: ArticleCommentsFragment) : Module() {
 
-    private val userSession by inject<UserSession>()
+    // From ApplicationScope
+    private val router by inject<StackRouter>()
 
     // From CommentsScope
     private val voteCommentViewModelFactory by inject<VoteCommentViewModel.Factory>()
-//
+
     // From ArticleCommentsScope
-    private val articleCommentsViewModelProvider by inject<GetArticleCommentsViewModelProvider>()
-//    private val commentsViewModelFactory by inject<GetArticleCommentsViewModel.Factory>()
+    private val commentsViewModelFactory by inject<GetArticleCommentsViewModel.Factory>()
 
     init {
         Toothpick.openScopes(ApplicationScope::class, CommentsScope::class, ArticleCommentsScope2::class).inject(this)
         bind<Fragment>().toInstance(fragment)
+
+        bind<CommentsNavigation>().toInstance(buildCommentsNavigation(fragment))
 
         val voteCommentViewModelProvider = VoteCommentViewModelProvider(fragment, voteCommentViewModelFactory)
         bind<VoteCommentViewModelProvider>().toInstance(voteCommentViewModelProvider)
 
         bind<ContentCommentAdapter>().toProvider(ContentCommentAdapterProvider::class)
 
+        val articleCommentsViewModelProvider = GetArticleCommentsViewModelProvider(commentsViewModelFactory)
         bind<GetArticleCommentsViewModel>().toInstance(articleCommentsViewModelProvider.get(fragment))
+    }
+
+    private fun buildCommentsNavigation(fragment: ArticleCommentsFragment): CommentsNavigation {
+        val articleId = fragment.arguments.articleId
+        val articleTitle = fragment.arguments.articleTitle
+        val fragmentManager = fragment.requireActivity().supportFragmentManager
+        return CommentsNavigation(router, articleId, articleTitle, fragmentManager)
     }
 }

--- a/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/viewmodel/DiscussionCommentsViewModelProvider.kt
+++ b/application/android/app/src/main/java/com/makentoshe/habrachan/application/android/screen/comments/viewmodel/DiscussionCommentsViewModelProvider.kt
@@ -5,10 +5,11 @@ import androidx.lifecycle.ViewModelProviders
 import com.makentoshe.habrachan.application.android.common.comment.di.provider.ViewModelFragmentProvider
 import javax.inject.Inject
 
-internal class DiscussionCommentsViewModelProvider : ViewModelFragmentProvider<DiscussionCommentsViewModel> {
+internal class DiscussionCommentsViewModelProvider(
+    private val factory: DiscussionCommentsViewModel.Factory
+) : ViewModelFragmentProvider<DiscussionCommentsViewModel> {
 
     @Inject
-    lateinit var factory: DiscussionCommentsViewModel.Factory
 
     override fun get(fragment: Fragment): DiscussionCommentsViewModel {
         return ViewModelProviders.of(fragment, factory)[DiscussionCommentsViewModel::class.java]


### PR DESCRIPTION
Previously di may load a state from already closed article for displaying a discussion comments and causes several internal errors. These errors wasn't anr but anyway...